### PR TITLE
Добавлен webSocketManager

### DIFF
--- a/src/webSocket/AppWebSocketError.ts
+++ b/src/webSocket/AppWebSocketError.ts
@@ -1,0 +1,17 @@
+import { AppError, AppErrorValue } from "../AppError";
+
+export class AppWebSocketError extends AppError {
+  static isWebSocketError(data: any): data is AppWebSocketError {
+    return data instanceof AppWebSocketError;
+  }
+
+  static buildFromInternalWebSocketError(webSocketError: any) {
+    return new AppWebSocketError({ message: webSocketError.message, errors: {} }, webSocketError);
+  }
+
+  constructor(private _error: { message: string; errors: Record<string, AppErrorValue> }, public webSocketError?: any) {
+    super();
+    this.setMessage(_error.message);
+    this.setErrors(_error.errors);
+  }
+}

--- a/src/webSocket/Connection.ts
+++ b/src/webSocket/Connection.ts
@@ -1,0 +1,64 @@
+import Decoder from "jsonous/Decoder";
+import { array } from "jsonous";
+
+import { AppWebSocketError } from "./AppWebSocketError";
+import { ConnectionInterface, ConnectionStatus } from "./index";
+
+export class Connection implements ConnectionInterface {
+  constructor({
+    onHandler,
+    emitHandler,
+    getStatusHandler,
+  }: {
+    onHandler: (eventName: string, callback: (...args: any[]) => void) => any;
+    emitHandler: (eventName: string, ...args: any[]) => any;
+    getStatusHandler: () => ConnectionStatus;
+  }) {
+    this.__on = onHandler;
+    this.__emit = emitHandler;
+    this.getStatus = getStatusHandler;
+  }
+
+  private readonly __on: (eventName: string, callback: (...args: any[]) => void) => any;
+
+  private readonly __emit: (eventName: string, ...args: any[]) => any;
+
+  applyError!: (error: AppWebSocketError) => Promise<AppWebSocketError>;
+
+  on<MessageDecoderValue>(
+    eventName: string,
+    callback: (...messages: MessageDecoderValue[]) => void,
+    serverMessageDecoder?: Decoder<MessageDecoderValue>,
+  ) {
+    const eventHandler = async (...serverMessages: any) => {
+      if (!serverMessageDecoder) {
+        callback(...serverMessages);
+        return;
+      }
+
+      const [data, decoderError] = array(serverMessageDecoder)
+        .decodeAny(serverMessages)
+        .cata<[MessageDecoderValue[], string | null]>({
+          Ok: (val) => [val, null],
+          Err: (err) => [null!, err],
+        });
+
+      if (!decoderError) {
+        callback(...data);
+        return;
+      }
+
+      throw await this.applyError(
+        new AppWebSocketError({ message: `Message parsing error: ${decoderError}`, errors: {} }),
+      );
+    };
+
+    this.__on(eventName, (...args: any) => eventHandler(...args).catch(console.error));
+  }
+
+  emit(eventName: string, ...args: any[]) {
+    this.__emit(eventName, ...args);
+  }
+
+  getStatus!: () => ConnectionStatus;
+}

--- a/src/webSocket/index.ts
+++ b/src/webSocket/index.ts
@@ -1,0 +1,169 @@
+import { Service } from "typedi";
+import Decoder from "jsonous/Decoder";
+
+import { AppWebSocketError } from "./AppWebSocketError";
+
+import { template } from "../template";
+
+export enum ConnectionStatus {
+  DISCONNECTED = "DISCONNECTED",
+  CONNECTING = "CONNECTING",
+  CONNECTED = "CONNECTED",
+  DISCONNECTING = "DISCONNECTING",
+  RECONNECTING = "RECONNECTING",
+}
+
+export interface ConnectionInterface {
+  emit: (eventName: string, ...args: any[]) => void;
+  on: <MessageDecoderValue>(
+    eventName: string,
+    callback: (...args: MessageDecoderValue[]) => void,
+    serverMessageDecoder?: Decoder<MessageDecoderValue>,
+  ) => void;
+  getStatus: () => ConnectionStatus;
+  applyError: (error: AppWebSocketError) => Promise<AppWebSocketError>;
+}
+
+type CreateConnection = {
+  url: string;
+};
+
+interface ConnectionData {
+  urlParams?: Record<string, string | number>;
+  options?: { disableBeforeErrorMiddlewares?: boolean; keysToDeleteBeforeErrorMiddleware?: string[] };
+}
+
+interface InternalSocketManagerInterface {
+  connect: (config: InternalSocketManagerConnectionConfig) => Promise<ConnectionInterface>;
+}
+
+type InternalSocketManagerConnectionConfig = {
+  url: string;
+  baseURL: string;
+};
+
+type BeforeErrorMiddleware = (data: {
+  error: AppWebSocketError;
+  config: InternalSocketManagerConnectionConfig;
+  shareData: Record<string, any>;
+}) => AppWebSocketError | Promise<AppWebSocketError | null> | null;
+
+@Service({ global: true })
+export class WebSocketManager {
+  private activeConnections: Record<string, ConnectionInterface> = {};
+
+  static baseURL = "";
+
+  static internalSocketManager: InternalSocketManagerInterface;
+
+  private static beforeErrorMiddlewareMap: Record<string, BeforeErrorMiddleware> = {};
+
+  static addBeforeErrorMiddleware(subscriptionKey: string, middleware: BeforeErrorMiddleware) {
+    WebSocketManager.beforeErrorMiddlewareMap[subscriptionKey] = middleware;
+  }
+
+  static deleteBeforeErrorMiddleware(subscriptionKey: string) {
+    delete WebSocketManager.beforeErrorMiddlewareMap[subscriptionKey];
+  }
+
+  private static async applyAllBeforeErrorMiddleware(
+    error: AppWebSocketError,
+    config: InternalSocketManagerConnectionConfig,
+    keysToDeleteMiddleware: string[] = [],
+  ) {
+    const shareData: Record<string, any> = {};
+
+    keysToDeleteMiddleware.forEach((key) => {
+      WebSocketManager.deleteBeforeErrorMiddleware(key);
+    });
+
+    const beforeErrorMiddleware = Object.values(WebSocketManager.beforeErrorMiddlewareMap);
+
+    for (let i = 0; i < beforeErrorMiddleware.length; i++) {
+      const middleware = beforeErrorMiddleware[i];
+      const middlewareResult = await middleware({ error, config, shareData });
+      if (!middlewareResult) break;
+
+      error = middlewareResult;
+    }
+
+    return error;
+  }
+
+  private static async applyError(
+    error: AppWebSocketError,
+    connectionConfig: InternalSocketManagerConnectionConfig,
+    connectionData: ConnectionData = {},
+  ) {
+    if (connectionData.options?.disableBeforeErrorMiddlewares) return error;
+    return await WebSocketManager.applyAllBeforeErrorMiddleware(
+      error,
+      connectionConfig,
+      connectionData.options?.keysToDeleteBeforeErrorMiddleware,
+    );
+  }
+
+  private static async makeConnect({
+    url,
+    connectionData: { urlParams },
+  }: CreateConnection & {
+    connectionData: ConnectionData;
+  }) {
+    const connectionData: InternalSocketManagerConnectionConfig = {
+      url,
+      baseURL: WebSocketManager.baseURL,
+    };
+
+    if (urlParams) {
+      connectionData.url = template(connectionData.url!, urlParams);
+    }
+
+    try {
+      const connection = await WebSocketManager.internalSocketManager.connect(connectionData);
+      return [{ connectionData, connection }, null] as const;
+    } catch (internalWebSocketError) {
+      return [
+        null,
+        { connectionData, internalWebSocketError } as {
+          connectionData: InternalSocketManagerConnectionConfig;
+          internalWebSocketError: any;
+        },
+      ] as const;
+    }
+  }
+
+  createConnection<DecoderValue>({ url }: CreateConnection) {
+    return async (connectionData: ConnectionData = {}) => {
+      const activeConnection = this.activeConnections[url];
+
+      if (activeConnection && activeConnection.getStatus() === ConnectionStatus.CONNECTED) {
+        return activeConnection;
+      }
+
+      delete this.activeConnections[url];
+
+      const [connectionResult, connectionError] = await WebSocketManager.makeConnect({
+        url,
+        connectionData,
+      });
+
+      if (connectionError) {
+        throw await WebSocketManager.applyError(
+          AppWebSocketError.buildFromInternalWebSocketError(connectionError.internalWebSocketError),
+          connectionError.connectionData,
+          connectionData,
+        );
+      }
+
+      if (!connectionResult) return null!;
+
+      connectionResult.connection.applyError = async (error: AppWebSocketError) =>
+        await WebSocketManager.applyError(error, connectionResult.connectionData, connectionData);
+
+      this.activeConnections[url] = connectionResult.connection;
+      return connectionResult.connection;
+    };
+  }
+}
+
+export { Connection } from "./Connection";

--- a/src/webSocket/webSocketManager.test.ts
+++ b/src/webSocket/webSocketManager.test.ts
@@ -1,0 +1,75 @@
+import { field, number, string, succeed } from "jsonous";
+
+import { fieldOrDefaultDecoder, toInstance, toInstanceDecoder } from "../decoders";
+
+import { WebSocketManager, ConnectionStatus, Connection } from "./index";
+
+async function createConnection(url: string) {
+  return Promise.resolve({
+    status: "Connected" as const,
+    on: (eventName: string, callback: (...args: any[]) => void) =>
+      setTimeout(() => callback({ count: 1 }, { count: 2 }, { count: 3, text: eventName }), 1000),
+    send: (eventName: string, ...args: any[]) => undefined,
+  });
+}
+
+const connectionStatusMap = {
+  Connected: ConnectionStatus.CONNECTED,
+};
+
+WebSocketManager.baseURL = "ws:/test-host";
+
+WebSocketManager.internalSocketManager = {
+  connect: async ({ baseURL, url }) => {
+    const connection = await createConnection(baseURL + url);
+
+    expect(baseURL + url).toBe("ws:/test-host/hub-address-1");
+
+    return new Connection({
+      onHandler: connection.on,
+      emitHandler: connection.send,
+      getStatusHandler: () => connectionStatusMap[connection.status],
+    });
+  },
+};
+
+const webSocketManager = new WebSocketManager();
+const createTestConnection = webSocketManager.createConnection({ url: "/hub-address-{id}" });
+
+class MessageEntity {
+  count!: number;
+
+  text?: string;
+}
+
+test("webSocketManager message decoding", (done) => {
+  createTestConnection({ urlParams: { id: 1 } }).then((connection) => {
+    connection.on<MessageEntity>(
+      "event",
+      (...messages) => {
+        expect(messages).not.toStrictEqual([
+          { count: 1, text: undefined },
+          { count: 2, text: undefined },
+          { count: 3, text: "event" },
+        ]);
+
+        expect(messages).toStrictEqual([
+          toInstance(MessageEntity)({ count: 1, text: undefined }),
+          toInstance(MessageEntity)({ count: 2, text: undefined }),
+          toInstance(MessageEntity)({ count: 3, text: "event" }),
+        ]);
+        done();
+      },
+      succeed({})
+        .assign("count", field("count", number))
+        .assign("text", fieldOrDefaultDecoder("text", string, undefined))
+        .andThen(toInstanceDecoder(MessageEntity)),
+    );
+  });
+});
+
+test("webSocketManager status", () => {
+  createTestConnection({ urlParams: { id: 1 } }).then((connection) => {
+    expect(connection.getStatus()).toBe(ConnectionStatus.CONNECTED);
+  });
+});


### PR DESCRIPTION
Идея заключается в том, что бы создать менеджер, который позволит работать с ws без привязки к библиотеке. Позволит декодировать сообщения, получаемые при прослушивании событий. А также будет осуществлять перехват и обработку ошибок, как и requestManager.

Для использования, необходимо, описать внутренний менеджер. После чего можно устанавливать соединения, подписываться и отправлять события.

Вот небольшой пример

![image](https://user-images.githubusercontent.com/60779381/146940997-b7be4a4c-b85a-42ec-962b-4062c0252a03.png)

При повторном создании соединения, менеджер смотрит, если есть открытое соединение с таким же url, то возвращает его, иначе создает новое.


Есть возможность добавления middleware для перехвата ошибок, список перехватчиков применяется и при установке подключения и при получении сообщения.

Вот так можно добавлять и удалять 
```
WebSocketManager.addBeforeErrorMiddleware("test", ({error}) => error)
WebSocketManager.deleteBeforeErrorMiddleware("test");
```

Также можно отключать определенные middleware или сразу все при создании соединения

Вот небольшой пример

![image](https://user-images.githubusercontent.com/60779381/146941324-733ca361-a263-4f56-9764-f6547286e5a2.png)

Пример прослушивания события. Метод on принимает третьим аргументов декодер для сообщения

![image](https://user-images.githubusercontent.com/60779381/146942018-4a162b41-8a67-41a7-a3fa-c1301b5a1f7d.png)

